### PR TITLE
Replace hardcoded French String with Translation Reference

### DIFF
--- a/Resources/views/Dashboard/two_columns.html.twig
+++ b/Resources/views/Dashboard/two_columns.html.twig
@@ -2,7 +2,7 @@
 
 {% block title %}{{ 'title_dashboard'|trans({}, 'SonataAdminBundle') }}{% endblock%}
 {% block breadcrumb %}
-    <li><a href="{{ url('sonata_admin_dashboard') }}">{{ 'breadcrumb.link_dashboard'|trans }}</a></li>
+    <li><a href="{{ url('sonata_admin_dashboard') }}">{{ 'breadcrumb.link_dashboard'|trans({}, 'PrestaCMSCoreBundle') }}</a></li>
 {% endblock %}
 {% block content %}
     <div class="row-fluid">


### PR DESCRIPTION
"Tableau de bord" and a link to /admin/fr was hardcoded.
