### PR TITLE
Update sonata media bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3.2",
         "sonata-project/admin-bundle":"2.2.*",
         "sonata-project/user-bundle": "2.2.*",
-        "sonata-project/media-bundle":"2.2.*",
+        "sonata-project/media-bundle":"2.3.*",
         "sonata-project/easy-extends-bundle":"2.1.*",
         "sonata-project/intl-bundle": "2.2.*",
         "presta/sonata-navigation-bundle": "1.0.*",


### PR DESCRIPTION
Update SonataProjectMediaBundle requirement to 2.3 (fix requirement conflict with tilleuls/ckeditor-sonata-media-bundle on our default symfony-prestacms project)
