### PR TITLE
Revert SonataMediaBundle requirement to 2.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3.2",
         "sonata-project/admin-bundle":"2.2.*",
         "sonata-project/user-bundle": "2.2.*",
-        "sonata-project/media-bundle":"2.3.*",
+        "sonata-project/media-bundle":"2.2.*",
         "sonata-project/easy-extends-bundle":"2.1.*",
         "sonata-project/intl-bundle": "2.2.*",
         "presta/sonata-navigation-bundle": "1.0.*",


### PR DESCRIPTION
SonataMedia 2.3 is not fully compatible with SonataAdmin 2.2.

Issues on linkin' media on entity and on media edit page.
